### PR TITLE
feat: task toggle group error

### DIFF
--- a/src/components/category-group/index.tsx
+++ b/src/components/category-group/index.tsx
@@ -1,0 +1,26 @@
+import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group'
+import { capitalize } from 'lodash'
+
+interface ICategoryGroupProps {
+  categories: string[]
+  selectedCategory: string
+  onCategoryChange: (value: string) => void
+}
+
+export const CategoryGroup = ({ categories, selectedCategory, onCategoryChange }: ICategoryGroupProps) => {
+  return (
+    <ToggleGroup
+      size="sm"
+      type="single"
+      value={selectedCategory}
+      onValueChange={onCategoryChange}
+      aria-label="Select Category"
+    >
+      {categories.map((category) => (
+        <ToggleGroupItem key={category} value={category}>
+          {capitalize(category)}
+        </ToggleGroupItem>
+      ))}
+    </ToggleGroup>
+  )
+}

--- a/src/components/task/task-card.tsx
+++ b/src/components/task/task-card.tsx
@@ -7,40 +7,41 @@ import { Badge } from '@/components/ui/badge'
 import { MarkdownProcessor } from '@/lib/md-processor'
 import { Card, CardDescription, CardFooter, CardTitle } from '../ui/card'
 
+type TaskState = 'open' | 'closed' | 'assigned'
+
 interface ITaskItemProps {
   item: Task
 }
 
-type TaskState = 'open' | 'closed' | 'assigned'
-
-const TaskStateBadge = ({ state }: { state: 'assigned' | 'open' | 'closed' }) => {
-  switch (state) {
-    case 'open':
-      return (
-        <Badge variant="default" className="bg-green-500">
-          Open
-        </Badge>
-      )
-    case 'closed':
-      return <Badge variant="default">Closed</Badge>
-    case 'assigned':
-      return (
-        <Badge variant="default" className="bg-blue-500">
-          Assigned
-        </Badge>
-      )
-    default:
-      return null
-  }
-}
-
 export const TaskCard = ({ item }: ITaskItemProps) => {
   let state: TaskState
+  console.log(item.state)
 
   if (item.state === 'open') {
     state = item.assignees.length ? 'assigned' : 'open'
   } else {
     state = 'closed'
+  }
+
+  const TaskStateBadge = ({ state }: { state: TaskState }) => {
+    switch (state) {
+      case 'open':
+        return (
+          <Badge variant="default" className="bg-green-500">
+            Open
+          </Badge>
+        )
+      case 'closed':
+        return <Badge variant="default">Closed</Badge>
+      case 'assigned':
+        return (
+          <Badge variant="default" className="bg-blue-500">
+            Assigned
+          </Badge>
+        )
+      default:
+        return null
+    }
   }
 
   return (

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -73,7 +73,7 @@ export default function Dashboard() {
       setLeaderboard(data)
       setUserCount(totalCount || 0)
     })
-    fetchTasks({ project: '', offset: 0, limit: 1000, states: [] }).then((tasks) => {
+    fetchTasks({ project: '', offset: 0, limit: 1000 }).then((tasks) => {
       const openedTasks = (tasks?.data || []).filter((task) => task.state === 'open')
       setOpenedCount(openedTasks.length)
       setTotalCount(tasks?.pagination.totalCount || 0)

--- a/src/pages/mytask/index.tsx
+++ b/src/pages/mytask/index.tsx
@@ -1,9 +1,50 @@
+import { CategoryGroup } from '@/components/category-group'
 import { TaskCatalog } from '@/components/task'
+import { fetchMyTasks } from '@/service'
+import { MyTaskState } from '@/types'
+import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+
+const DEFAULT_CATEGORIES = ['all', 'open', 'closed']
 
 export default function MyTask() {
+  const [selectedCategory, setSelectedCategory] = useState<string>('all')
+  const [page, setPage] = useState(1)
+  const pageSize = 9
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['tasks', page, pageSize, selectedCategory],
+    queryFn: () =>
+      fetchMyTasks({
+        offset: (page - 1) * pageSize,
+        limit: pageSize,
+        states: selectedCategory !== 'all' ? [selectedCategory as MyTaskState] : [],
+      }),
+  })
+
+  const onCategoryChange = (value: string) => {
+    setSelectedCategory(value)
+  }
+
   return (
-    <div className="mx-auto max-w-7xl px-4 py-4 lg:px-12">
-      <TaskCatalog />
-    </div>
+    <main className="flex flex-col gap-5">
+      <header className="flex flex-col space-y-2" aria-label="Filter Controls">
+        <div className="flex space-x-2">
+          <CategoryGroup
+            selectedCategory={selectedCategory}
+            onCategoryChange={onCategoryChange}
+            categories={DEFAULT_CATEGORIES}
+          />
+        </div>
+      </header>
+      <TaskCatalog
+        page={page}
+        pageSize={pageSize}
+        isLoading={isLoading}
+        totalPages={Math.ceil((data?.pagination.totalCount || 0) / pageSize)}
+        tasks={data?.data}
+        setPage={setPage}
+      />
+    </main>
   )
 }

--- a/src/pages/task/index.tsx
+++ b/src/pages/task/index.tsx
@@ -10,9 +10,33 @@ import {
 import { Input } from '@/components/ui/input'
 import { LucideSearch } from 'lucide-react'
 import { TaskCatalog } from '@/components/task'
+import { CategoryGroup } from '@/components/category-group'
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { fetchTasks } from '@/service'
+
+const ASSIGNMENT_STATUS = ['all', 'unassigned', 'assigned']
 
 export default function TaskPage() {
   const { project } = useParams<{ project: string }>()
+  const [selectedCategory, setSelectedCategory] = useState<string>('all')
+  const [page, setPage] = useState(1)
+  const pageSize = 9
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['tasks', project, page, pageSize, selectedCategory],
+    queryFn: () =>
+      fetchTasks({
+        project: project || '',
+        offset: (page - 1) * pageSize,
+        limit: pageSize,
+        assignmentStatus: selectedCategory !== 'all' ? selectedCategory : undefined,
+      }),
+  })
+
+  const onCategoryChange = (value: string) => {
+    setSelectedCategory(value)
+  }
 
   return (
     <>
@@ -34,12 +58,29 @@ export default function TaskPage() {
         </BreadcrumbList>
       </Breadcrumb>
       <div className="flex flex-col gap-5">
-        {/* // TODO: add search logic */}
         <div className="relative">
           <Input placeholder="Search tutorial title or description" className="bg-background/80 pl-8" />
           <LucideSearch className="absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2" />
         </div>
-        <TaskCatalog project={project} />
+        <main className="flex flex-col gap-5">
+          <header className="flex flex-col space-y-2" aria-label="Filter Controls">
+            <div className="flex space-x-2">
+              <CategoryGroup
+                selectedCategory={selectedCategory}
+                onCategoryChange={onCategoryChange}
+                categories={ASSIGNMENT_STATUS}
+              />
+            </div>
+          </header>
+          <TaskCatalog
+            page={page}
+            pageSize={pageSize}
+            totalPages={Math.ceil((data?.pagination.totalCount || 0) / pageSize)}
+            setPage={setPage}
+            isLoading={isLoading}
+            tasks={data?.data}
+          />
+        </main>
       </div>
     </>
   )

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -12,8 +12,8 @@ import {
   GithubRepo,
   Tutorial,
   PrRewardInfo,
-  TaskState,
   UserInfo,
+  MyTaskState,
 } from '@/types'
 import http from './instance'
 
@@ -169,14 +169,13 @@ export async function fetchTasks(params: {
   project: string
   offset: number
   limit: number
-  states: TaskState[]
   assignmentStatus?: string
 }) {
   const response = await http.get<IResultPaginationData<Task>>('/tasks', { params })
   return response.data
 }
 
-export async function fetchMyTasks(params: { offset: number; limit: number; states: TaskState[] }) {
+export async function fetchMyTasks(params: { offset: number; limit: number; states: MyTaskState[] }) {
   const response = await http.get<IResultPaginationData<Task>>('/my-tasks', { params })
   return response.data
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -286,4 +286,6 @@ export interface TransactionInfo {
   transactionId: string
 }
 
-export type TaskState = '' | 'open' | 'closed'
+export type MyTaskState = '' | 'open' | 'closed'
+
+export type TaskState = '' | 'assigned' | 'unassigned'


### PR DESCRIPTION
- Updated `category group` in tasks page to handle assignment status: "assigned" and "unassigned"
- Updated `cartegory group` in my tasks page to handle task status: "open" and "closed"
- Resolve dual category grouping error on task page