### PR TITLE
feat: change task toggle group

### DIFF
--- a/src/components/category-group/index.tsx
+++ b/src/components/category-group/index.tsx
@@ -1,0 +1,26 @@
+import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group'
+import { capitalize } from 'lodash'
+
+interface ICategoryGroupProps {
+  categories: string[]
+  selectedCategory: string
+  onCategoryChange: (value: string) => void
+}
+
+export const CategoryGroup = ({ categories, selectedCategory, onCategoryChange }: ICategoryGroupProps) => {
+  return (
+    <ToggleGroup
+      size="sm"
+      type="single"
+      value={selectedCategory}
+      onValueChange={onCategoryChange}
+      aria-label="Select Category"
+    >
+      {categories.map((category) => (
+        <ToggleGroupItem key={category} value={category}>
+          {capitalize(category)}
+        </ToggleGroupItem>
+      ))}
+    </ToggleGroup>
+  )
+}

--- a/src/components/task/index.tsx
+++ b/src/components/task/index.tsx
@@ -2,116 +2,38 @@ import { LoadingCards } from '../skeleton-card'
 import { TaskCard } from './task-card'
 import { EmptyTasks } from './empty-tasks'
 import PaginationFast from '@/components/pagination-fast'
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
-import { capitalize } from 'lodash'
-import { useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
-import { fetchMyTasks, fetchTasks } from '@/service'
-import { TaskState } from '@/types'
-
-// TODO: should separate this in another way since project task and my task have different filter
-const DEFAULT_CATEGORIES = ['all', 'open', 'closed']
-const ASSIGNMENT_STATUS = ['all', 'unassigned', 'assigned']
-
+import { Task } from '@/types'
 interface ITaskCatalog {
-  project?: string
+  page: number
+  pageSize: number
+  tasks?: Task[]
+  totalPages?: number
+  isLoading: boolean
+  setPage: (page: number) => void
 }
 
-export const TaskCatalog = ({ project }: ITaskCatalog) => {
-  const [page, setPage] = useState(1)
-  const [selectedCategory, setSelectedCategory] = useState<string>('open')
-  const [selectedAssignment, setSelectedAssignment] = useState<string>('unassigned')
-  const pageSize = 9
-  let queryKey
-  let queryFn
+export const TaskCatalog = ({ page, tasks, totalPages = 1, isLoading, setPage }: ITaskCatalog) => {
+  let renderedTasks
 
-  if (!project) {
-    queryKey = ['my-tasks', page, selectedCategory]
-    queryFn = () =>
-      fetchMyTasks({
-        offset: (page - 1) * pageSize,
-        limit: pageSize,
-        states: selectedCategory !== 'all' ? [selectedCategory as TaskState] : [],
-      })
+  if (isLoading) {
+    renderedTasks = <LoadingCards count={3} />
+  } else if (tasks && tasks.length) {
+    renderedTasks = tasks.map((item) => <TaskCard key={item._id} item={item} />)
   } else {
-    queryKey = ['tasks', project, page, pageSize, selectedCategory, selectedAssignment]
-    queryFn = () =>
-      fetchTasks({
-        project: project || '',
-        offset: (page - 1) * pageSize,
-        limit: pageSize,
-        states: selectedCategory !== 'all' ? [selectedCategory as TaskState] : [],
-        assignmentStatus: selectedAssignment !== 'all' ? selectedAssignment : undefined,
-      })
-  }
-
-  const { data, isLoading: loading } = useQuery({
-    queryKey: queryKey,
-    queryFn: queryFn,
-  })
-
-  const tasks = data?.data || []
-  const totalPages = Math.ceil((data?.pagination.totalCount || 0) / pageSize)
-
-  const handleCategoryChange = (value: string) => {
-    setSelectedCategory(value)
-  }
-
-  const handleAssignmentChange = (value: string) => {
-    setSelectedAssignment(value)
-  }
-
-  const Tasks = () => {
-    if (loading) return <LoadingCards count={3} />
-    if (tasks.length) {
-      return tasks.map((item) => <TaskCard key={item._id} item={item} />)
-    }
-    return <EmptyTasks />
+    renderedTasks = <EmptyTasks />
   }
 
   return (
-    <main className="flex flex-col gap-5">
-      <header className="flex flex-col space-y-2" aria-label="Filter Controls">
-        <div className="flex space-x-2">
-          <ToggleGroup
-            size="sm"
-            type="single"
-            value={selectedCategory}
-            onValueChange={handleCategoryChange}
-            aria-label="Select Category"
-          >
-            {DEFAULT_CATEGORIES.map((category) => (
-              <ToggleGroupItem key={category} value={category}>
-                {capitalize(category)}
-              </ToggleGroupItem>
-            ))}
-          </ToggleGroup>
-        </div>
-        {project && (
-          <ToggleGroup
-            size="sm"
-            type="single"
-            value={selectedAssignment}
-            onValueChange={handleAssignmentChange}
-            aria-label="Select Assignment Status"
-          >
-            {ASSIGNMENT_STATUS.map((status) => (
-              <ToggleGroupItem key={status} value={status}>
-                {capitalize(status)}
-              </ToggleGroupItem>
-            ))}
-          </ToggleGroup>
-        )}
-      </header>
+    <>
       <section className="grid gap-4 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3" aria-labelledby="tasks-heading">
         <h2 id="tasks-heading" className="sr-only">
           Tasks
         </h2>
-        <Tasks />
+        {renderedTasks}
       </section>
       <nav aria-label="Pagination">
         <PaginationFast page={page} totalPages={totalPages} onPageChange={setPage} />
       </nav>
-    </main>
+    </>
   )
 }

--- a/src/components/task/task-card.tsx
+++ b/src/components/task/task-card.tsx
@@ -7,31 +7,10 @@ import { Badge } from '@/components/ui/badge'
 import { MarkdownProcessor } from '@/lib/md-processor'
 import { Card, CardDescription, CardFooter, CardTitle } from '../ui/card'
 
-interface ITaskItemProps {
-  item: Task
-}
-
 type TaskState = 'open' | 'closed' | 'assigned'
 
-const TaskStateBadge = ({ state }: { state: 'assigned' | 'open' | 'closed' }) => {
-  switch (state) {
-    case 'open':
-      return (
-        <Badge variant="default" className="bg-green-500">
-          Open
-        </Badge>
-      )
-    case 'closed':
-      return <Badge variant="default">Closed</Badge>
-    case 'assigned':
-      return (
-        <Badge variant="default" className="bg-blue-500">
-          Assigned
-        </Badge>
-      )
-    default:
-      return null
-  }
+interface ITaskItemProps {
+  item: Task
 }
 
 export const TaskCard = ({ item }: ITaskItemProps) => {
@@ -41,6 +20,27 @@ export const TaskCard = ({ item }: ITaskItemProps) => {
     state = item.assignees.length ? 'assigned' : 'open'
   } else {
     state = 'closed'
+  }
+
+  const TaskStateBadge = ({ state }: { state: TaskState }) => {
+    switch (state) {
+      case 'open':
+        return (
+          <Badge variant="default" className="bg-green-500">
+            Open
+          </Badge>
+        )
+      case 'closed':
+        return <Badge variant="default">Closed</Badge>
+      case 'assigned':
+        return (
+          <Badge variant="default" className="bg-blue-500">
+            Assigned
+          </Badge>
+        )
+      default:
+        return null
+    }
   }
 
   return (

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -73,7 +73,7 @@ export default function Dashboard() {
       setLeaderboard(data)
       setUserCount(totalCount || 0)
     })
-    fetchTasks({ project: '', offset: 0, limit: 1000, states: [] }).then((tasks) => {
+    fetchTasks({ project: '', offset: 0, limit: 1000 }).then((tasks) => {
       const openedTasks = (tasks?.data || []).filter((task) => task.state === 'open')
       setOpenedCount(openedTasks.length)
       setTotalCount(tasks?.pagination.totalCount || 0)

--- a/src/pages/mytask/index.tsx
+++ b/src/pages/mytask/index.tsx
@@ -1,9 +1,50 @@
+import { CategoryGroup } from '@/components/category-group'
 import { TaskCatalog } from '@/components/task'
+import { fetchMyTasks } from '@/service'
+import { MyTaskState } from '@/types'
+import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+
+const DEFAULT_CATEGORIES = ['all', 'open', 'closed']
 
 export default function MyTask() {
+  const [selectedCategory, setSelectedCategory] = useState<string>('all')
+  const [page, setPage] = useState(1)
+  const pageSize = 9
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['tasks', page, pageSize, selectedCategory],
+    queryFn: () =>
+      fetchMyTasks({
+        offset: (page - 1) * pageSize,
+        limit: pageSize,
+        states: selectedCategory !== 'all' ? [selectedCategory as MyTaskState] : [],
+      }),
+  })
+
+  const onCategoryChange = (value: string) => {
+    setSelectedCategory(value)
+  }
+
   return (
-    <div className="mx-auto max-w-7xl px-4 py-4 lg:px-12">
-      <TaskCatalog />
-    </div>
+    <main className="flex flex-col gap-5">
+      <header className="flex flex-col space-y-2" aria-label="Filter Controls">
+        <div className="flex space-x-2">
+          <CategoryGroup
+            selectedCategory={selectedCategory}
+            onCategoryChange={onCategoryChange}
+            categories={DEFAULT_CATEGORIES}
+          />
+        </div>
+      </header>
+      <TaskCatalog
+        page={page}
+        pageSize={pageSize}
+        isLoading={isLoading}
+        totalPages={Math.ceil((data?.pagination.totalCount || 0) / pageSize)}
+        tasks={data?.data}
+        setPage={setPage}
+      />
+    </main>
   )
 }

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -12,8 +12,8 @@ import {
   GithubRepo,
   Tutorial,
   PrRewardInfo,
-  TaskState,
   UserInfo,
+  MyTaskState,
 } from '@/types'
 import http from './instance'
 
@@ -169,14 +169,14 @@ export async function fetchTasks(params: {
   project: string
   offset: number
   limit: number
-  states: TaskState[]
   assignmentStatus?: string
+  states?: string
 }) {
   const response = await http.get<IResultPaginationData<Task>>('/tasks', { params })
   return response.data
 }
 
-export async function fetchMyTasks(params: { offset: number; limit: number; states: TaskState[] }) {
+export async function fetchMyTasks(params: { offset: number; limit: number; states: MyTaskState[] }) {
   const response = await http.get<IResultPaginationData<Task>>('/my-tasks', { params })
   return response.data
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -286,4 +286,6 @@ export interface TransactionInfo {
   transactionId: string
 }
 
-export type TaskState = '' | 'open' | 'closed'
+export type MyTaskState = '' | 'open' | 'closed'
+
+export type TaskState = '' | 'assigned' | 'unassigned'


### PR DESCRIPTION
- Updated category group in tasks page to handle assignment status: `assigned`, `unassigned`, `open` and `closed`
- Updated cartegory group in my tasks page to handle task status: `open` and `closed`