### PR TITLE
chore: add Github Action to sync main into dev

### DIFF
--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -1,0 +1,165 @@
+name: Sync Main to Dev
+
+on:
+  pull_request: 
+    branches:
+      - main
+    types:
+      - closed
+
+  # manual trigger
+  workflow_dispatch:
+    inputs:
+      simulate_failure:
+        description: 'Simulate failure for testing'
+        required: false
+        default: 'false'
+
+jobs:
+  sync-main-to-dev:
+    if : github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Gives write access to repository contents
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update dev branch
+        id: sync
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin dev
+          git checkout dev
+          git merge origin/main --no-ff -m "chore: sync main to dev"
+          git push origin dev
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Send Feishu notification on success
+        if: ${{ success() && inputs.simulate_failure != 'true' }}
+        run: |
+          timestamp=$(date +%s)
+          curl -X POST \
+          -H "Content-Type: application/json" \
+          -d '{
+            "msg_type": "interactive",
+            "card": {
+              "config": { "wide_screen_mode": true },
+              "header": {
+                "title": { "tag": "plain_text", "content": "✅ Dev Branch Sync Completed" },
+                "template": "green"
+              },
+              "elements": [
+                {
+                  "tag": "div",
+                  "text": {
+                    "tag": "lark_md",
+                    "content": "📦 **Repository:** [${{ github.repository }}](github.com/${{ github.repository }})"
+                  }
+                },
+                {
+                  "tag": "div",
+                  "text": {
+                    "tag": "lark_md",
+                    "content": "🔄 **Workflow:** [${{ github.workflow }}](github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+                  }
+                },
+                {
+                  "tag": "div",
+                  "text": {
+                    "tag": "lark_md",
+                    "content": "🚀 **Triggered by:** ${{ github.actor }}"
+                  }
+                },
+                {
+                  "tag": "div",
+                  "text": {
+                    "tag": "lark_md",
+                    "content": "🔔 **Event:** ${{ github.event_name }}"
+                  }
+                },
+                {
+                    "tag": "action",
+                    "actions": [
+                        {
+                            "tag": "button",
+                            "text": {
+                                "tag": "plain_text",
+                                "content": "View Action Details"
+                            },
+                            "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                            "type": "primary"
+                        }
+                    ]
+                }
+              ]
+            }
+          }' \
+          ${{ secrets.FEISHU_BOT_WEBHOOK_URL }}
+
+      - name: Send Feishu notification on failure
+        if: ${{ failure() || inputs.simulate_failure == 'true' }}
+
+        run: |
+          timestamp=$(date +%s)
+          curl -X POST \
+          -H "Content-Type: application/json" \
+          -d '{
+            "msg_type": "interactive",
+            "card": {
+              "config": { "wide_screen_mode": true },
+              "header": {
+                "title": { "tag": "plain_text", "content": "❌ Dev Branch Sync Failed" },
+                "template": "red"
+              },
+              "elements": [
+                {
+                  "tag": "div",
+                  "text": {
+                    "tag": "lark_md",
+                    "content": "📦 **Repository:** [${{ github.repository }}](github.com/${{ github.repository }})"
+                  }
+                },
+                {
+                  "tag": "div",
+                  "text": {
+                    "tag": "lark_md",
+                    "content": "🔄 **Workflow:** [${{ github.workflow }}](github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+                  }
+                },
+                {
+                  "tag": "div",
+                  "text": {
+                    "tag": "lark_md",
+                    "content": "🚀 **Triggered by:** ${{ github.actor }}"
+                  }
+                },
+                {
+                  "tag": "div",
+                  "text": {
+                    "tag": "lark_md",
+                    "content": "🔔 **Event:** ${{ github.event_name }}"
+                  }
+                },
+                {
+                    "tag": "action",
+                    "actions": [
+                        {
+                            "tag": "button",
+                            "text": {
+                                "tag": "plain_text",
+                                "content": "View Action Details"
+                            },
+                            "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                            "type": "primary"
+                        }
+                    ]
+                }
+              ]
+            }
+          }' \
+          ${{ secrets.FEISHU_BOT_WEBHOOK_URL }}


### PR DESCRIPTION
worked on #129 : Add a workflow to sync `main` to `dev`

Hi @hunknownz @null0x62 , please help to review this pr.

同步成功时，发送成功通知到飞书群（测试群）：
<img width="624" alt="Screenshot 2025-04-05 at 20 48 53" src="https://github.com/user-attachments/assets/072d96fd-17de-47f5-8ee3-7be0f7ede69c" />
查看dev分支发现dev分支已自动同步
<img width="1020" alt="Screenshot 2025-04-05 at 20 35 06" src="https://github.com/user-attachments/assets/2770c999-4176-4422-bcff-00dfe84d4b09" />

同步失败时（手动触发），发送失败通知到飞书群（测试群）：
<img width="618" alt="Screenshot 2025-04-05 at 20 49 51" src="https://github.com/user-attachments/assets/4a60b015-9d7a-44bb-a334-11538d2983bf" />


Q&A：
1. 为什么提交到main而不是dev？
因为无论是main还是dev，这个workflow不影响产品的发布，他的作用是同步main分支到dev分支，如果合并到dev分支无法起作用。
2. 什么时候会触发？
只有当pull request merged的时候会触发，合并之后会发送到飞书的devops群。
3. 代码很冗余，成功卡片和失败卡片明明是同一个模板，为什么没有合并？
目前只想要功能，怎么方便怎么写。而且成功和失败通知卡片是没有设计的，不一定是同一个模板，那就暂时认为他们是不同的，所以没有把他们写到一起而是分开写，虽然看上去90%相同。后面确定了设计或者有新的需求，可以建新的issue解决目前的问题。
